### PR TITLE
Tweak some image positions

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -156,7 +156,7 @@ imageAreas = {
       [2.5, 2.5],
       [97.5, 2.5],
       [97.5, 33],
-      [66, 40],
+      [65, 41],
       [2.5, 32]
     ]),
     scaleStyle: 'fill',
@@ -171,7 +171,7 @@ imageAreas = {
   // Right Art
   vdb_leftArt: {
     pathShape: coordinatesToPathShape([
-      [66, 40],
+      [65, 41],
       [97.5, 33],
       [97.5, 90],
       [40, 81]
@@ -189,7 +189,7 @@ imageAreas = {
   vdb_rightArt: {
     pathShape: coordinatesToPathShape([
       [2.5, 32],
-      [66, 40],
+      [65, 41],
       [40, 81],
       [2.5, 77]
     ]),

--- a/villain-deck-back/index.html
+++ b/villain-deck-back/index.html
@@ -148,7 +148,7 @@
           <input type="text" data-image-purpose="villainNameArt" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageOffsetY">Y Position</label>
-          <input type="range" data-image-purpose="villainNameArt" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="10">
+          <input type="range" data-image-purpose="villainNameArt" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="0">
           <input type="text" data-image-purpose="villainNameArt" class="contentInput rangeText" data-default="10">
 
           <label for="inputImageScale">Zoom</label>


### PR DESCRIPTION
## What?
A bit of whitespace was showing on the top and right images on the back. This repositioning eliminates that. In addition, the logo started too high up, so I've reset the Y position to 0 by default.

## How was it tested?
Comparison: 
![oldback](https://user-images.githubusercontent.com/1555041/211673726-44262f0b-dea0-4fb6-8919-fdf98b17bf21.png)
![ministryback](https://user-images.githubusercontent.com/1555041/211673740-39a3afe0-4514-4d58-9d44-ece7f78faea5.png)

## Reviewers
@Colcoction 
