### PR TITLE
Add JSON output for Hero decks

### DIFF
--- a/hero-deck-front/index.html
+++ b/hero-deck-front/index.html
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Boogaloo&family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Work+Sans:ital,wght@0,100;0,200;0,300;0,350;0,370;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-  
+
   <!-- Other fonts -->
   <link href="https://fonts.cdnfonts.com/css/unmasked-bb" rel="stylesheet">
   <link href="https://fonts.cdnfonts.com/css/avengeance-mightiest-avenger" rel="stylesheet">
@@ -189,10 +189,11 @@
       </div>
     </div>
     <div class="inputGroup">
-      <label for="jsonInput">JSON Input</label>
+      <label for="jsonInput">JSON Input/Output</label>
       <div id="jsonError" class="errorMessage"></div>
       <textarea rows="10" class="contentInput" id="jsonInput"></textarea>
       <button style="margin-top: 10px;" id="parseJsonInputButton">Parse JSON</button>
+      <button style="margin-top: 10px;" id="outputJsonButton">Output JSON</button>
     </div>
   </div>
 

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -90,6 +90,11 @@ $('#parseJsonInputButton').on('click', function () {
   $('#jsonError').text("");
 })
 
+// Output JSON Input button
+$('#outputJsonButton').on('click', function () {
+  outputJSONData();
+})
+
 // Toggle high contrast phase labels
 $('#inputUseHighConstrast').on('input', function () {
   useHighContrastPhaseLabels = this.checked;
@@ -178,9 +183,9 @@ function parseJSONData(data) {
     }
     $('#inputImageScale').val(zoomVal);
   } else {
-    $('#inputImageScale').val(0);
+    $('#inputImageScale').val(100);
   }
-  if('Suddenly' in data) {
+  if('Suddenly' in data && data.Suddenly.toUpperCase() == "TRUE") {
     $('#suddenly')[0].checked = true;
     suddenly = true;
   } else {
@@ -188,6 +193,29 @@ function parseJSONData(data) {
     suddenly = false;
   }
   drawCardCanvas();
+}
+
+function outputJSONData() {
+  var imageURL = "";
+  if (cardArtImage != null) {
+    imageURL = cardArtImage.src;
+  }
+  var outputJSON = `{
+    "Title": ${JSON.stringify($('#inputTitle').val())},
+    "HP": ${JSON.stringify($('#inputHP').val())},
+    "Keywords": ${JSON.stringify($('#inputKeywords').val())},
+    "BoldedTerms": ${JSON.stringify($('#inputBoldWords').val())},
+    "GameText": ${JSON.stringify($('#inputEffect').val())},
+    "GameTextSize": ${JSON.stringify($('#inputEffectTextSize').val())},
+    "Quote": ${JSON.stringify($('#inputQuote').val())},
+    "Attribution": ${JSON.stringify($('#inputAttribution').val())},
+    "ImageURL": ${JSON.stringify(imageURL)},
+    "ImageX": ${JSON.stringify($('#inputImageOffsetX').val())},
+    "ImageY": ${JSON.stringify($('#inputImageOffsetY').val())},
+    "ImageZoom": ${JSON.stringify($('#inputImageScale').val())},
+    "Suddenly": "${JSON.stringify($('#suddenly')[0].checked)}"
+  },`;
+  $('#jsonInput').val(outputJSON);
 }
 
 

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -134,6 +134,11 @@ function parseJSONData(data) {
   } else {
     $('#inputKeywords').val('');
   }
+  if('BoldedTerms' in data) {
+    $('#inputBoldWords').val(data.BoldedTerms);
+  } else {
+    $('#inputBoldWords').val('');
+  }
   if('GameText' in data) {
     $('#inputEffect').val(data.GameText);
   } else {


### PR DESCRIPTION
## What?
Adding JSON Output for Hero Decks (will eventually port it to all decks)
Now we have a button to output the status of a card to the JSON field, making it easy to "save" decks!

NOTE: Do NOT merge this until #9 has been merged and deployed. It relies on a field introduced in that PR.

## How was it tested?
![image](https://user-images.githubusercontent.com/1555041/229022513-086bb88d-2750-42dc-a879-abd07b12f0cf.png)

## Reviewers
@Colcoction 