### PR TITLE
Apply common js files & move colors to common-before

### DIFF
--- a/common-before.js
+++ b/common-before.js
@@ -77,3 +77,22 @@ $('.closeButton, .screenOverlayNegativeSpace').on('click', function (e) {
     // Make screen overlay and info boxes invisible
     $('.screenOverlay, .overlayBox').css({ 'display': 'none' });
 })
+
+
+/*
+============================================================================
+Shared effect text values
+============================================================================
+*/
+// I don't think the high contrast values are actually CYMK... >:|
+
+const colorStartPhaseOriginal = '#3fae49';
+const colorStartPhaseHighContrast = '#4bc244';
+const colorPlayPhaseOriginal = '#fff200';
+const colorPlayPhaseHighContrast = '#fff72f';
+const colorPowerPhaseOriginal = '#79509e';
+const colorPowerPhaseHighContrast = '#a76fb9';
+const colorDrawPhaseOriginal = '#00aeef';
+const colorDrawPhaseHighContrast = '#3db7e2';
+const colorEndPhaseOriginal = '#ee2d35';
+const colorEndPhaseHighContrast = '#f34747';

--- a/environment-deck-back/index.html
+++ b/environment-deck-back/index.html
@@ -163,6 +163,7 @@
 
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
+
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/environment-deck-front/index.html
+++ b/environment-deck-front/index.html
@@ -199,6 +199,7 @@
 
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
+
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -193,19 +193,6 @@ Effect text values
 ============================================================================
 */
 
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
-
 let useHighContrastPhaseLabels = true;
 let suddenly = false;
 

--- a/hero-character-card-back/index.html
+++ b/hero-character-card-back/index.html
@@ -190,6 +190,7 @@
 
   </div>
 
+  
   <!-- Scripts -->
   
   <!-- jQuery -->

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -220,19 +220,6 @@ Effect text values
 ============================================================================
 */
 
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
-
 let useHighContrastPhaseLabels = true;
 
 const effectBaseFontSize = pw(3.95); // Font size for most effect text

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -318,19 +318,6 @@ Effect text values
 ============================================================================
 */
 
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
-
 let useHighContrastPhaseLabels = true;
 
 const effectBaseFontSize = pw(3.95); // Font size for most effect text

--- a/hero-deck-front/index.html
+++ b/hero-deck-front/index.html
@@ -206,8 +206,13 @@
 
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
+
+  <!-- Common script -->
+  <script src="../common-before.js"></script>
   <!-- Script specific to this page -->
   <script src="./script.js"></script>
+  <!-- Common script -->
+  <script src="../common-after.js"></script>
 
 </body>
 

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -1,8 +1,3 @@
-// Establish canvas
-var canvas = document.getElementById("myCanvas");
-var ctx = canvas.getContext("2d");
-ctx.save();
-
 // Default canvas preview size
 $(canvasContainer).css({ width: 400 });
 
@@ -229,21 +224,6 @@ function outputJSONData() {
 Effect text values
 ============================================================================
 */
-
-const colorBlack = '#231f20';
-
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
 
 let useHighContrastPhaseLabels = true;
 let suddenly = false;

--- a/villain-deck-front/index.html
+++ b/villain-deck-front/index.html
@@ -194,8 +194,13 @@
 
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
+
+  <!-- Common script -->
+  <script src="../common-before.js"></script>
   <!-- Script specific to this page -->
   <script src="./script.js"></script>
+  <!-- Common script -->
+  <script src="../common-after.js"></script>
 
 </body>
 

--- a/villain-deck-front/script.js
+++ b/villain-deck-front/script.js
@@ -96,21 +96,6 @@ Effect text values
 ============================================================================
 */
 
-const colorBlack = '#231f20';
-
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
-
 let useHighContrastPhaseLabels = true;
 let suddenly = false;
 


### PR DESCRIPTION
- Adds `common-before.js` and `common-after.js` to all of the files (does not do anything with `imageAreas` though)
- Moves color declarations like `colorBlack` and `colorStartPhaseOriginal` to `common-before.js`

I can start integrating the range sliders / data-image props after this.