### PR TITLE
Consolidate canvas sizes

### DIFF
--- a/common-before.js
+++ b/common-before.js
@@ -1,11 +1,49 @@
-
+/*
+============================================================================
+Global variables
+============================================================================
+*/
+// Orientations. This should be declared in the page's script configurations.
+const VERTICAL = "vertical";
+const HORIZONTAL = "horizontal";
+// Card preview sizes. These should match the text content of buttons on the page.
+const SMALL = "Small";
+const MEDIUM = "Medium";
+const LARGE = "Large";
+const CARD_PREVIEW_SIZES = [SMALL, MEDIUM, LARGE];
+/** Maps canvas container widths based on user-provided sizes (small, med, large) and card orientation. Used in {@link setCanvasWidth()}. */
+const canvasSizes = new Map([
+    [VERTICAL, new Map([
+        [SMALL,   250],
+        [MEDIUM,  350],
+        [LARGE,   450],
+    ])],
+    [HORIZONTAL, new Map([
+        [SMALL,   600],
+        [MEDIUM,  800],
+        [LARGE,  1000],
+    ])]
+]);
+// Colors for card effects
+// I don't think the high contrast values are actually CYMK... >:|
 const colorBlack = '#231f20';
+const colorStartPhaseOriginal = '#3fae49';
+const colorStartPhaseHighContrast = '#4bc244';
+const colorPlayPhaseOriginal = '#fff200';
+const colorPlayPhaseHighContrast = '#fff72f';
+const colorPowerPhaseOriginal = '#79509e';
+const colorPowerPhaseHighContrast = '#a76fb9';
+const colorDrawPhaseOriginal = '#00aeef';
+const colorDrawPhaseHighContrast = '#3db7e2';
+const colorEndPhaseOriginal = '#ee2d35';
+const colorEndPhaseHighContrast = '#f34747';
 
-// Establish canvas
-var canvas = document.getElementById("myCanvas");
-var ctx = canvas.getContext("2d");
-ctx.save();
 
+/*
+============================================================================
+Global functions
+============================================================================
+*/
 // Short function to convert percentage (ex: 50) into pixels
 function pw(percentageWidth) {
     return percentageWidth * canvas.width / 100;
@@ -13,6 +51,29 @@ function pw(percentageWidth) {
 function ph(percentageHeight) {
     return percentageHeight * canvas.height / 100;
 }
+
+// Sets canvas width given a card preview size, using the page's pre-configured orientation
+function setCanvasWidth(cardPreviewSize) {
+    $('#canvasContainer').css({ width: canvasSizes.get(ORIENTATION).get(cardPreviewSize) });
+}
+
+/*
+============================================================================
+Common listeners
+============================================================================
+*/
+// Canvas preview size button
+$('.previewSizeButton').on('click', function (e) {
+    // Get the button's text
+    let buttonText = e.target.textContent;
+    // This should never happen, but if the text content doesn't match an expected type, log a warning and set it to medium
+    if (!CARD_PREVIEW_SIZES.includes(buttonText)) {
+        console.warn(`Someone tried to set the size to ${buttonText}, but the only available sizes are [${CARD_PREVIEW_SIZES.join(", ")}]. Setting the size to ${MEDIUM}.`);
+        buttonText = MEDIUM;
+    }
+    // Based on the button's text (the name of the size), determine the new canvas size
+    setCanvasWidth(buttonText);
+});
 
 
 // Range sliders with text box - when one changes, copy its value to the other
@@ -26,7 +87,6 @@ $('.rangeText').on('input', function (e) {
 $('.rangeText').each(function (e) {
     $(this).val($(this).prev().val());
 })
-
 
 // Populate inputs with default values on startup
 $('*[data-image-purpose]').each(function () {
@@ -81,18 +141,11 @@ $('.closeButton, .screenOverlayNegativeSpace').on('click', function (e) {
 
 /*
 ============================================================================
-Shared effect text values
+Initialization Logic
 ============================================================================
 */
-// I don't think the high contrast values are actually CYMK... >:|
-
-const colorStartPhaseOriginal = '#3fae49';
-const colorStartPhaseHighContrast = '#4bc244';
-const colorPlayPhaseOriginal = '#fff200';
-const colorPlayPhaseHighContrast = '#fff72f';
-const colorPowerPhaseOriginal = '#79509e';
-const colorPowerPhaseHighContrast = '#a76fb9';
-const colorDrawPhaseOriginal = '#00aeef';
-const colorDrawPhaseHighContrast = '#3db7e2';
-const colorEndPhaseOriginal = '#ee2d35';
-const colorEndPhaseHighContrast = '#f34747';
+// Establish canvas
+var canvas = document.getElementById("myCanvas");
+var ctx = canvas.getContext("2d");
+ctx.save();
+setCanvasWidth(MEDIUM);

--- a/environment-deck-back/index.html
+++ b/environment-deck-back/index.html
@@ -164,6 +164,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "horizontal";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/environment-deck-back/script.js
+++ b/environment-deck-back/script.js
@@ -1,21 +1,3 @@
-
-
-// Default canvas preview size
-$('#canvasContainer').css({ width: 600 });
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 600; } else
-    if (sizeName === 'Medium') { sizeValue = 800; } else
-      if (sizeName === 'Large') { sizeValue = 1000; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/environment-deck-front/index.html
+++ b/environment-deck-front/index.html
@@ -200,6 +200,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "horizontal";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -1,26 +1,3 @@
-
-// Default canvas preview size
-$(canvasContainer).css({ width: 600 });
-
-// Resize canvas preview size upon user input (old range method)
-// $('#inputCardPreviewSize').on('input', function(e) {
-//   let previewWidth = e.target.value;
-//   $('#canvasContainer').css({width: previewWidth});
-// })
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 600; }
-  else if (sizeName === 'Medium') { sizeValue = 800; }
-  else if (sizeName === 'Large') { sizeValue = 1000; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/hero-character-card-back/index.html
+++ b/hero-character-card-back/index.html
@@ -196,6 +196,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -1,20 +1,3 @@
-
-// Default canvas preview size
-$('#canvasContainer').css({ width: 350 });
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 250; }
-  else if (sizeName === 'Medium') { sizeValue = 350; }
-  else if (sizeName === 'Large') { sizeValue = 450; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/hero-character-card-front/index.html
+++ b/hero-character-card-front/index.html
@@ -275,6 +275,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -1,20 +1,3 @@
-
-// Default canvas preview size
-$('#canvasContainer').css({ width: 350 });
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 250; }
-  else if (sizeName === 'Medium') { sizeValue = 350; }
-  else if (sizeName === 'Large') { sizeValue = 450; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/hero-deck-back/index.html
+++ b/hero-deck-back/index.html
@@ -253,6 +253,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/hero-deck-back/script.js
+++ b/hero-deck-back/script.js
@@ -1,21 +1,3 @@
-
-
-// Default canvas preview size
-$('#canvasContainer').css({ width: 400 });
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 300; } else
-    if (sizeName === 'Medium') { sizeValue = 400; } else
-      if (sizeName === 'Large') { sizeValue = 500; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/hero-deck-front/index.html
+++ b/hero-deck-front/index.html
@@ -207,6 +207,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -1,25 +1,3 @@
-// Default canvas preview size
-$(canvasContainer).css({ width: 400 });
-
-// Resize canvas preview size upon user input (old range method)
-// $('#inputCardPreviewSize').on('input', function(e) {
-//   let previewWidth = e.target.value;
-//   $('#canvasContainer').css({width: previewWidth});
-// })
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 300; }
-  else if (sizeName === 'Medium') { sizeValue = 400; }
-  else if (sizeName === 'Large') { sizeValue = 500; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/villain-deck-back/index.html
+++ b/villain-deck-back/index.html
@@ -243,6 +243,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/villain-deck-back/script.js
+++ b/villain-deck-back/script.js
@@ -1,21 +1,3 @@
-
-
-// Default canvas preview size
-$('#canvasContainer').css({ width: 400 });
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 300; } else
-    if (sizeName === 'Medium') { sizeValue = 400; } else
-      if (sizeName === 'Large') { sizeValue = 500; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');

--- a/villain-deck-front/index.html
+++ b/villain-deck-front/index.html
@@ -195,6 +195,10 @@
   <!-- jQuery -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js'></script>
 
+  <!-- Declarations -->
+  <script>
+    const ORIENTATION = "vertical";
+  </script>
   <!-- Common script -->
   <script src="../common-before.js"></script>
   <!-- Script specific to this page -->

--- a/villain-deck-front/script.js
+++ b/villain-deck-front/script.js
@@ -1,30 +1,3 @@
-// Establish canvas
-var canvas = document.getElementById("myCanvas");
-var ctx = canvas.getContext("2d");
-ctx.save();
-
-// Default canvas preview size
-$(canvasContainer).css({ width: 400 });
-
-// Resize canvas preview size upon user input (old range method)
-// $('#inputCardPreviewSize').on('input', function(e) {
-//   let previewWidth = e.target.value;
-//   $('#canvasContainer').css({width: previewWidth});
-// })
-
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-  // Get the button's text (the name of the size)
-  let sizeName = e.target.textContent;
-  // Based on name, determine new size
-  let sizeValue = 0;
-  if (sizeName === 'Small') { sizeValue = 300; }
-  else if (sizeName === 'Medium') { sizeValue = 400; }
-  else if (sizeName === 'Large') { sizeValue = 500; }
-  // Apply the new display size of the canvas
-  $('#canvasContainer').css({ width: sizeValue });
-})
-
 // Download button
 $('#downloadButton').on('click', function () {
   let link = document.createElement('a');


### PR DESCRIPTION
## Summary
- Added some organizing headers to `common-before.js`
- Consolidated logic for setting canvas width into `common-before.js`
- Added a configuration "script" (just some global variables specific to each page to the start of each card-creation page, and added an orientation configuration to each.

## Test Plan
For each page:
1. Visit the page. Verify that it loads with a medium-sized card preview.
2. Set the size to small, large, and medium. Verify that the canvas size updates to match.

![image](https://user-images.githubusercontent.com/8094985/232250635-def5003e-9826-4cfc-9843-0a843591368f.png)
![image](https://user-images.githubusercontent.com/8094985/232250643-c08380f2-8188-4ece-a4a5-0046ebb56748.png)
![image](https://user-images.githubusercontent.com/8094985/232250692-ed8adcf1-bfc2-4c97-a21a-f92c06dd206a.png)

## Reviewers
@Colcoction 
@sjzhu 