### PR TITLE
Moving & Consolidating Listeners

### DIFF
--- a/common-before.js
+++ b/common-before.js
@@ -149,103 +149,6 @@ function resetDataImageSettings(imagePurpose) {
 
 /*
 ============================================================================
-Common listeners
-============================================================================
-*/
-// Canvas preview size button
-$('.previewSizeButton').on('click', function (e) {
-    // Get the button's text
-    let buttonText = e.target.textContent;
-    // This should never happen, but if the text content doesn't match an expected type, log a warning and set it to medium
-    if (!CARD_PREVIEW_SIZES.includes(buttonText)) {
-        console.warn(`Someone tried to set the size to ${buttonText}, but the only available sizes are [${CARD_PREVIEW_SIZES.join(", ")}]. Setting the size to ${MEDIUM}.`);
-        buttonText = MEDIUM;
-    }
-    // Based on the button's text (the name of the size), determine the new canvas size
-    setCanvasWidth(buttonText);
-});
-
-
-// Range sliders with text box - when one changes, copy its value to the other
-$('.rangeSlider').on('input', function (e) {
-    $(this).next().val($(this).val());
-});
-$('.rangeText').on('input', function (e) {
-    $(this).prev().val($(this).val());
-});
-// Also, when the page loads, copy the default value from the slider into the text box
-$('.rangeText').each(function (e) {
-    $(this).val($(this).prev().val());
-});
-
-
-// Populate inputs with default values on startup
-$('*[data-image-purpose]').each(function () {
-    if (this.dataset.default) {
-        this.value = this.dataset.default;
-    }
-});
-
-
-// Resets art adjustments and removes an image for buttons that are tagged with both relevant classes. This allows us to avoid
-// making multiple redundant calsl to drawCardCanvas after the reset functions are complete.
-$('.adjustmentResetButton.clearImageButton').on('click', function () {
-    const areaName = this.dataset.imagePurpose;
-    resetDataImageSettings(areaName);
-    // Remove uploaded image
-    $(`.contentInput[data-image-purpose="${areaName}"][type="file"]`).each(function () {
-        this.value = '';
-        loadedUserImages[areaName] = null;
-    });
-    // Redraw canvas (since "on input" event didn't trigger)
-    drawCardCanvas();
-});
-
-
-$('.adjustmentResetButton:not(.clearImageButton)').on('click', function () {
-    const areaName = this.dataset.imagePurpose;
-    resetDataImageSettings(areaName)
-    // Redraw canvas (since "on input" event didn't trigger)
-    drawCardCanvas();
-});
-
-
-// Info buttons
-$('.infoButton').on('click', function (e) {
-    // Make screen overlay visible
-    $('.screenOverlay').css({ 'display': 'block' });
-    // Make specific info box visible
-    let buttonText = e.target.textContent;
-    let boxId = '';
-    if (buttonText == 'Documentation') {
-        boxId = 'documentation';
-    }
-    else if (buttonText == 'Credits') {
-        boxId = 'credits';
-    }
-    $('.' + boxId).css({ 'display': 'block' });
-});
-
-
-// Close buttons (in info boxes)
-$('.closeButton, .screenOverlayNegativeSpace').on('click', function (e) {
-    // Make screen overlay and info boxes invisible
-    $('.screenOverlay, .overlayBox').css({ 'display': 'none' });
-});
-
-
-// Download button
-$('#downloadButton').on('click', function () {
-    // Use the title input for the default file name
-    const link = document.createElement('a');
-    link.download = `${$("#inputTitle")?.val()?.trim() || DEFAULT_DOWNLOAD_NAME}.png`;
-    link.href = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-    link.click();
-    link.remove();
-});
-
-/*
-============================================================================
 Initialization Logic
 ============================================================================
 */
@@ -292,3 +195,5 @@ Modifiable Global Variables
 ============================================================================
 */
 let boxHeightOffset = 0;
+let useHighContrastPhaseLabels = true;
+let suddenly = false;

--- a/environment-deck-back/script.js
+++ b/environment-deck-back/script.js
@@ -1,8 +1,3 @@
-// Draw the canvas on window load. Helpful for situations like testing with a hardcoded effect text
-$(window).on('load', function () {
-  drawCardCanvas();
-})
-
 /*
 ============================================================================
 Loading and app prep-work
@@ -45,9 +40,6 @@ $('#inputImageFile').on('input', function (e) {
   }
 })
 
-
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
 
 /*
 ============================================================================

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -14,24 +14,7 @@ $('#parseJsonInputButton').on('click', function () {
     return;
   }
   $('#jsonError').text("");
-})
-
-// Toggle high contrast phase labels
-$('#inputUseHighConstrast').on('input', function () {
-  useHighContrastPhaseLabels = this.checked;
-  drawCardCanvas();
-})
-
-// Toggle Suddenly!
-$('#suddenly').on('input', function () {
-  suddenly = this.checked;
-  drawCardCanvas();
-})
-
-// Draw the canvas on window load. Helpful for situations like testing with a hardcoded effect text
-$(window).on('load', function () {
-  drawCardCanvas();
-})
+});
 
 /*
 ============================================================================
@@ -122,9 +105,6 @@ function parseJSONData(data) {
 Effect text values
 ============================================================================
 */
-
-let useHighContrastPhaseLabels = true;
-let suddenly = false;
 
 const effectBaseFontSize = ph(4.05); // Font size for most effect text
 let effectFontScale = 1; // This will update with the user input value
@@ -223,8 +203,6 @@ $('#inputImageFile').on('input', function (e) {
   }
 })
 
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
 
 /*
 ============================================================================

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -85,10 +85,6 @@ $('.inputImageFile').on('input', function () {
 })
 
 
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
-
-
 /*
 ============================================================================
 Drawing the canvas
@@ -193,8 +189,6 @@ Effect text values
 ============================================================================
 */
 
-let useHighContrastPhaseLabels = true;
-
 const effectBaseFontSize = pw(3.95); // Font size for most effect text
 let effectFontScale = 1; // This will update with the user input value
 let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
@@ -230,15 +224,3 @@ let currentOffsetY = 0; // Current y position for draw commands
 var effectBoldList = ["START PHASE", "PLAY PHASE", "POWER PHASE", "DRAW PHASE", "END PHASE", "PERFORM", "ACCOMPANY"];
 // These phrases will be automatically italicized
 var effectItalicsList = ["PERFORM", "ACCOMPANY"];
-
-
-/*
-============================================================================
-Effect text functions
-============================================================================
-*/
-// Toggle high contrast phase labels
-$('#inputUseHighConstrast').on('input', function () {
-  useHighContrastPhaseLabels = this.checked;
-  drawCardCanvas();
-});

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -89,10 +89,6 @@ $('.inputImageFile').on('input', function () {
 })
 
 
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
-
-
 /*
 ============================================================================
 Drawing the canvas
@@ -248,8 +244,6 @@ function drawHP() {
 Effect text values
 ============================================================================
 */
-let useHighContrastPhaseLabels = true;
-
 const effectBaseFontSize = pw(3.95); // Font size for most effect text
 let effectFontScale = 1; // This will update with the user input value
 let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
@@ -312,15 +306,3 @@ function loadEffectList() {
   effectBoldList = Array.from(newBoldList);
   effectItalicsList = Array.from(newItalicsList);
 }
-
-/*
-============================================================================
-Effect text functions
-============================================================================
-*/
-
-// Toggle high contrast phase labels
-$('#inputUseHighConstrast').on('input', function () {
-  useHighContrastPhaseLabels = this.checked;
-  drawCardCanvas();
-});

--- a/hero-deck-back/script.js
+++ b/hero-deck-back/script.js
@@ -61,9 +61,6 @@ $('.inputImageFile').on('input', function () {
 })
 
 
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
-
 /*
 ============================================================================
 Drawing the canvas

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -1,25 +1,3 @@
-// Info buttons
-$('.infoButton').on('click', function (e) {
-  // Make screen overlay visible
-  $('.screenOverlay').css({ 'display': 'block' });
-  // Make specific info box visible
-  let buttonText = e.target.textContent;
-  let boxId = '';
-  if (buttonText == 'Documentation') {
-    boxId = 'documentation';
-  }
-  else if (buttonText == 'Credits') {
-    boxId = 'credits';
-  }
-  $('.' + boxId).css({ 'display': 'block' });
-})
-
-// Close buttons (in info boxes)
-$('.closeButton, .screenOverlayNegativeSpace').on('click', function (e) {
-  // Make screen overlay and info boxes invisible
-  $('.screenOverlay, .overlayBox').css({ 'display': 'none' });
-})
-
 // Parse JSON input buttom
 $('#parseJsonInputButton').on('click', function () {
   // attempt to parse the JSON
@@ -41,24 +19,7 @@ $('#parseJsonInputButton').on('click', function () {
 // Output JSON Input button
 $('#outputJsonButton').on('click', function () {
   outputJSONData();
-})
-
-// Toggle high contrast phase labels
-$('#inputUseHighConstrast').on('input', function () {
-  useHighContrastPhaseLabels = this.checked;
-  drawCardCanvas();
-})
-
-// Toggle Suddenly!
-$('#suddenly').on('input', function () {
-  suddenly = this.checked;
-  drawCardCanvas();
-})
-
-// Draw the canvas on window load. Helpful for situations like testing with a hardcoded effect text
-$(window).on('load', function () {
-  drawCardCanvas();
-})
+});
 
 /*
 ============================================================================
@@ -177,10 +138,6 @@ function outputJSONData() {
 Effect text values
 ============================================================================
 */
-
-let useHighContrastPhaseLabels = true;
-let suddenly = false;
-
 const effectBaseFontSize = pw(4.05); // Font size for most effect text
 let effectFontScale = 1; // This will update with the user input value
 let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);

--- a/villain-deck-back/script.js
+++ b/villain-deck-back/script.js
@@ -61,9 +61,6 @@ $('.inputImageFile').on('input', function () {
 })
 
 
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
-
 /*
 ============================================================================
 Drawing the canvas

--- a/villain-deck-front/script.js
+++ b/villain-deck-front/script.js
@@ -1,30 +1,8 @@
-// Toggle high contrast phase labels
-$('#inputUseHighConstrast').on('input', function () {
-  useHighContrastPhaseLabels = this.checked;
-  drawCardCanvas();
-})
-
-// Toggle Suddenly!
-$('#suddenly').on('input', function () {
-  suddenly = this.checked;
-  drawCardCanvas();
-})
-
-// Draw the canvas on window load. Helpful for situations like testing with a hardcoded effect text
-$(window).on('load', function () {
-  drawCardCanvas();
-})
-
-
 /*
 ============================================================================
 Effect text values
 ============================================================================
 */
-
-let useHighContrastPhaseLabels = true;
-let suddenly = false;
-
 const effectBaseFontSize = pw(4.05); // Font size for most effect text
 let effectFontScale = 1; // This will update with the user input value
 let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
@@ -153,9 +131,6 @@ $('#inputImageFile').on('input', function () {
   $('.inputImageOffsetY').prop('value', '0');
   $('.inputImageScale').prop('value', '100');
 });
-
-// Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
 
 /*
 ============================================================================


### PR DESCRIPTION
## Summary
- Moved all listeners to `common-after.js` so that on-load triggers will apply to whatever is created in the `script.js` and `common-before.js` file (otherwise we couldn't consolidate the on-load canvas render in the same spot as the other listeners).
- Consolidated the on-input and on-load listeners that redraw the canvas.
- Consolidated suddenly & phase contrast toggles.

## Test Plan
- Create cards on all of the pages. Verify that stuff works as it should.
- Turn Suddenly and High-Contrast Phase Indicators on & off for all pages that have them. Verify that the changes are updating properly.

## Screenshots
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/7cf10051-711d-46e0-b312-e6fda89e1cf7)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/23448e77-fad5-46e0-8937-efff8be65961)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/6c34fc88-3d55-47b6-857c-dbd65648b2f9)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/790c77a0-91c7-4d84-9c11-c2e2b45caa44)

## Reviewers
@Colcoction 
@sjzhu 