### PR TITLE
Refactoring body text globals

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -644,7 +644,7 @@ function drawBodyText(parsedBlocks) {
 
   // Get and apply the text scale the user chose
   effectFontScale = $('#inputEffectTextSize').prop('value') / 100; // Result is between 0 and 1
-  effectFontSize = effectBaseFontSize * effectFontScale;
+  effectFontSize = EFFECT_BASE_FONT_SIZE * effectFontScale;
   lineHeight = effectBaseLineHeight * effectFontScale;
   spaceWidth = effectFontSize * spaceWidthFactor;
 
@@ -724,7 +724,7 @@ function drawPhaseBlock(phase, isFirstBlock) {
 function drawIndentBlock(indentLabel, indentContent, isFirstBlock) {
   // If this is the first block, adjust the Y position, bringing the text up a little more if the font is smaller.
   if (isFirstBlock) {
-    currentOffsetY = currentOffsetY - effectBaseFontSize + effectFontSize;
+    currentOffsetY = currentOffsetY - EFFECT_BASE_FONT_SIZE + effectFontSize;
   }
 
   // Set shared characteristics for all labels:
@@ -738,7 +738,7 @@ function drawIndentBlock(indentLabel, indentContent, isFirstBlock) {
      //   - This spacing looks correct at a casual glance. We should check it more closely.
      //   - This does NOT render the special bullet point character in hero character incap text, because we can't find the thing. It might be a custom graphic.
     labelContent = `${CARD_FORM === DECK ? "     " : ""}${indentLabel}`;
-    ctx.font = `400 ${effectFontSize}px ${effectFontFamily}`;
+    ctx.font = `400 ${effectFontSize}px ${EFFECT_FONT_FAMILY}`;
   } else {
     labelContent = indentLabel;
     ctx.font = `900 ${effectFontSize * INDENT_LABEL_SIZE_FACTOR}px ${INDENT_LABEL_FONT_FAMILY}`
@@ -759,7 +759,7 @@ function drawIndentBlock(indentLabel, indentContent, isFirstBlock) {
 function drawSimpleBlock(simpleContent, isFirstBlock) {
   // If this is the first block, adjust the Y position, bringing the text up a little more if the font is smaller
   if (isFirstBlock) {
-    currentOffsetY = currentOffsetY - effectBaseFontSize + effectFontSize;
+    currentOffsetY = currentOffsetY - EFFECT_BASE_FONT_SIZE + effectFontSize;
   }
 
   // Replace spaces after numbers (and X variables) with non-breaking spaces
@@ -815,11 +815,11 @@ function drawSimpleBlock(simpleContent, isFirstBlock) {
     let thisWord = getWordProperties(word); // returns an object: {text, isBold, isItalics}
 
     // Set drawing styles
-    let weightValue = effectFontWeight;
+    let weightValue = EFFECT_FONT_WEIGHT;
     let styleValue = "normal";
     if (thisWord.isBold) { weightValue = "600" }
     if (thisWord.isItalics) { styleValue = "italic" }
-    ctx.font = weightValue + ' ' + styleValue + ' ' + effectFontSize + 'px ' + effectFontFamily;
+    ctx.font = weightValue + ' ' + styleValue + ' ' + effectFontSize + 'px ' + EFFECT_FONT_FAMILY;
     ctx.fillStyle = colorBlack;
 
     // Break up special bold/italics phrases into their component words
@@ -865,7 +865,7 @@ function drawSimpleBlock(simpleContent, isFirstBlock) {
         // Get width of word without ending punctuation
         let mainWordWidth = ctx.measureText(stringToDraw).width;
         // Set the font styles to effect text default
-        ctx.font = effectFontWeight + ' ' + 'normal' + ' ' + effectFontSize + 'px ' + effectFontFamily;
+        ctx.font = EFFECT_FONT_WEIGHT + ' ' + 'normal' + ' ' + effectFontSize + 'px ' + EFFECT_FONT_FAMILY;
         // Draw the punctuation
         let drawX = currentOffsetX + mainWordWidth;
         ctx.fillText(endingPunctuation, drawX, currentOffsetY);

--- a/common-before.js
+++ b/common-before.js
@@ -97,7 +97,6 @@ const PHASE_COLOR_MAP = new Map([
         [END_PHASE, "#f34747"],
     ])],
 ]);
-// Map of phase text properties
 // PHASE_FONT_SIZE_MAP is declared at the bottom of the page because it depends on canvas size
 const PHASE_FONT_FAMILY = 'Avengeance Mightiest Avenger';
 const PHASE_SIZE_FACTOR = 1;
@@ -106,6 +105,9 @@ const INDENT_LABEL_FONT_FAMILY = "Work Sans";
 const INDENT_LABEL_SIZE_FACTOR = 1.08;
 // Line joins (we only use miter)
 const MITER = "miter";
+// Body text properties
+const EFFECT_FONT_WEIGHT = 400;
+const EFFECT_FONT_FAMILY = 'Noto Sans';
 
 /*
 ============================================================================
@@ -163,6 +165,7 @@ setCanvasWidth(MEDIUM);
 Initialization-Dependent Global Variables
 ============================================================================
 */
+// Font size for phase labels
 const _phaseFontSizeMap = new Map([
     [DECK, new Map([
         [VERTICAL, pw(4.1)],
@@ -174,6 +177,8 @@ const _phaseFontSizeMap = new Map([
     ])],
 ]);
 const EFFECT_PHASE_FONT_SIZE = _phaseFontSizeMap.get(CARD_FORM)?.get(ORIENTATION);
+
+// Size of the phase icons placed next to labels
 const _phaseIconSizeMap = new Map([
     [DECK, new Map([
         [VERTICAL, pw(8.9)],
@@ -189,11 +194,38 @@ const _phaseIconSizeMap = new Map([
 ]);
 const PHASE_ICON_X = _phaseIconSizeMap.get(CARD_FORM)?.get(ORIENTATION);
 
+// Font size for most effect text
+const _baseFontSizeMap = new Map([
+    [DECK, new Map([
+        [VERTICAL, pw(4.05)],
+        [HORIZONTAL, ph(4.05)],
+    ])],
+    [CHARACTER, new Map([
+        [VERTICAL, pw(3.95)],
+        // TODO: UW hasn't set up horizontal character cards yet, so we're leaving this null.
+        //       If you're reading this comment because you hit a null error, figure this
+        //       value out and update it! 
+        [HORIZONTAL, null],
+    ])],
+]);
+const EFFECT_BASE_FONT_SIZE = _baseFontSizeMap.get(CARD_FORM)?.get(ORIENTATION);
+
 /*
 ============================================================================
 Modifiable Global Variables
 ============================================================================
 */
+// The offset to apply to the height at which the body of a card is drawn.
 let boxHeightOffset = 0;
+
+// Whether to use high contrast phase labels
 let useHighContrastPhaseLabels = true;
+
+// Whether a card has the Suddenly! keyword
 let suddenly = false;
+
+// The scale of the body text and line height for a card. This is a value between 0 and 1, set by the user.
+let effectFontScale = 1;
+
+// The size of body text for a card. This is a convenience variable, derived from EFFECT_BASE_FONT_SIZE * effectFontScale 
+let effectFontSize = EFFECT_BASE_FONT_SIZE;

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -105,17 +105,6 @@ function parseJSONData(data) {
 Effect text values
 ============================================================================
 */
-
-const effectBaseFontSize = ph(4.05); // Font size for most effect text
-let effectFontScale = 1; // This will update with the user input value
-let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
-const effectFontWeight = 400; // Font weight for most effect text
-const effectFontFamily = 'Noto Sans'; // Font family for most effect text
-const effectPowerFontFamily = 'Work Sans'; // Font family for POWER: and REACTION:
-const effectPowerFontSizeFactor = 1.08; // POWER: will be drawn at effectFontSize times this value
-const effectPhaseFontFamily = 'Avengeance Mightiest Avenger';
-const effectPhaseFontSizeFactor = 1;
-
 // Space between words
 const spaceWidthFactor = 0.26;
 let spaceWidth = effectFontSize * spaceWidthFactor;

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -179,26 +179,11 @@ function drawCardCanvas() {
 }
 
 
-
-
-
-
 /*
 ============================================================================
 Effect text values
 ============================================================================
 */
-
-const effectBaseFontSize = pw(3.95); // Font size for most effect text
-let effectFontScale = 1; // This will update with the user input value
-let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
-const effectFontWeight = 400; // Font weight for most effect text
-const effectFontFamily = 'Noto Sans'; // Font family for most effect text
-const effectPowerFontFamily = 'Work Sans'; // Font family for POWER: and REACTION:
-const effectPowerFontSizeFactor = 1.08; // POWER: will be drawn at effectFontSize times this value
-const effectPhaseFontFamily = 'Avengeance Mightiest Avenger';
-const effectPhaseFontSizeFactor = 1;
-
 // Space between words
 const spaceWidthFactor = 0.26;
 let spaceWidth = effectFontSize * spaceWidthFactor;

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -244,16 +244,6 @@ function drawHP() {
 Effect text values
 ============================================================================
 */
-const effectBaseFontSize = pw(3.95); // Font size for most effect text
-let effectFontScale = 1; // This will update with the user input value
-let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
-const effectFontWeight = 400; // Font weight for most effect text
-const effectFontFamily = 'Noto Sans'; // Font family for most effect text
-const effectPowerFontFamily = 'Work Sans'; // Font family for POWER: and REACTION:
-const effectPowerFontSizeFactor = 1.08; // POWER: will be drawn at effectFontSize times this value
-const effectPhaseFontFamily = 'Avengeance Mightiest Avenger';
-const effectPhaseFontSizeFactor = 1;
-
 // Space between words
 const spaceWidthFactor = 0.26;
 let spaceWidth = effectFontSize * spaceWidthFactor;

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -138,12 +138,6 @@ function outputJSONData() {
 Effect text values
 ============================================================================
 */
-const effectBaseFontSize = pw(4.05); // Font size for most effect text
-let effectFontScale = 1; // This will update with the user input value
-let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
-const effectFontWeight = 400; // Font weight for most effect text
-const effectFontFamily = 'Noto Sans'; // Font family for most effect text
-
 // Space between words
 const spaceWidthFactor = 0.26;
 let spaceWidth = effectFontSize * spaceWidthFactor;
@@ -258,7 +252,6 @@ $('#inputImageFile').on('input', function (e) {
 })
 
 // Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
-$('.contentInput').on('input', drawCardCanvas);
 
 /*
 ============================================================================

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -252,6 +252,7 @@ $('#inputImageFile').on('input', function (e) {
 })
 
 // Whenever one of the content inputs has its value changed (including each character typed in a text input), redraw the canvas
+$('.contentInput').on('input', drawCardCanvas);
 
 /*
 ============================================================================

--- a/villain-deck-front/script.js
+++ b/villain-deck-front/script.js
@@ -3,16 +3,6 @@
 Effect text values
 ============================================================================
 */
-const effectBaseFontSize = pw(4.05); // Font size for most effect text
-let effectFontScale = 1; // This will update with the user input value
-let effectFontSize = effectBaseFontSize; // The font size that will be used (modifiable) ('px' unit is added later);
-const effectFontWeight = 400; // Font weight for most effect text
-const effectFontFamily = 'Noto Sans'; // Font family for most effect text
-const effectPowerFontFamily = 'Work Sans'; // Font family for POWER: and REACTION:
-const effectPowerFontSizeFactor = 1.08; // POWER: will be drawn at effectFontSize times this value
-const effectPhaseFontFamily = 'Avengeance Mightiest Avenger';
-const effectPhaseFontSizeFactor = 1;
-
 // Space between words
 const spaceWidthFactor = 0.26;
 let spaceWidth = effectFontSize * spaceWidthFactor;


### PR DESCRIPTION
## Summary

- Named some more const globals with SCREAMING_SNAKE_CASE
- Moved font weights, families, and sizes to `common-before.js` for body text
- Derived `EFFECT_BASE_FONT_SIZE` from card form & orientation
- Cleaned up some unused globals that were already replaced in previous refactors but never got pruned (e.g. `effectPhaseFontFamily` in `villain-deck-front/script.js`)

## Test Plan
Create a card with an indent block & a phase block on:

1. Hero deck fronts
2. Villain deck fronts
3. Environment deck fronts
4. Hero character card fronts
5. Hero character card backs

## Screenshots
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/ac5dd30c-1741-4aed-8e67-fcc39f0ae595)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/7d18983b-fe2e-48df-9c7b-c94cd950cb5d)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/7ba3fa10-391c-44db-9231-1ac767d500be)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/b7dbfec7-bd81-44be-a0c1-743f98a5b167)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/04217d89-dbe8-479d-83e1-906da4a126cf)

## Reviewers
@sjzhu 
@Colcoction 