### PR TITLE
Refactoring more globals

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -588,7 +588,7 @@ function parseCardBody() {
 /**
  * Given an array of parsed blocks, calculate the box height offset of a card.
  *
- * drawBodyText() alters the currentOffsetY, so we draw once and subtract that value from effectStartY to determine the height of the drawn body content. We add 137
+ * drawBodyText() alters the currentOffsetY, so we draw once and subtract that value from EFFECT_START_Y to determine the height of the drawn body content. We add 137
  * (the closest round number representing the height of 3 lines drawn in the same paragraph) to this in order to determine the offset that a hero body box would need in
  * order to fit all of the blocks that we parsed from the user input. Hero character card body boxes have a minimum size, so we min this value with 0 to determine the offset
  * of our box (increasing the offset moves our Y position *downwards*, so a positive number yields a smaller box).
@@ -596,7 +596,7 @@ function parseCardBody() {
 function adjustBoxHeightOffset(parsedBlocks) {
   boxHeightOffset = 0;
   drawBodyText(parsedBlocks);
-  boxHeightOffset = Math.min(Math.round(effectStartY - currentOffsetY + 137), 0);
+  boxHeightOffset = Math.min(Math.round(EFFECT_START_Y - currentOffsetY + 137), 0);
   currentOffsetY = 0;
 }
 
@@ -639,14 +639,14 @@ function drawCharacterBodyBox() {
 /** Given an array of blocks, draw the body of a card from a deck. */
 function drawBodyText(parsedBlocks) {
   // Initialize positioning values
-  currentOffsetX = effectStartX;
-  currentOffsetY = effectStartY + boxHeightOffset;
+  currentOffsetX = EFFECT_START_X;
+  currentOffsetY = EFFECT_START_Y + boxHeightOffset;
 
   // Get and apply the text scale the user chose
   effectFontScale = $('#inputEffectTextSize').prop('value') / 100; // Result is between 0 and 1
   effectFontSize = EFFECT_BASE_FONT_SIZE * effectFontScale;
   lineHeight = effectBaseLineHeight * effectFontScale;
-  spaceWidth = effectFontSize * spaceWidthFactor;
+  spaceWidth = effectFontSize * SPACE_WIDTH_FACTOR;
 
   // Draw the blocks
   parsedBlocks.forEach((block, index) => {
@@ -659,7 +659,7 @@ function drawBodyText(parsedBlocks) {
 /** Draws a single block from the array of parsed blocks. */
 function drawBlock(block, isFirstBlock) {
   // Reset indentation to default
-  currentIndentX = effectStartX;
+  currentIndentX = EFFECT_START_X;
 
   if (block.type === SPACE_BLOCK) {
     drawSpaceBlock(isFirstBlock);
@@ -690,7 +690,7 @@ function drawPhaseBlock(phase, isFirstBlock) {
   const phaseText = PHASE_TEXT_MAP.get(phase);
 
   // Adjust line height based on whether this is the first block
-  currentOffsetY = isFirstBlock ? effectStartY : currentOffsetY - lineHeight + lineHeight * prePhaseLineHeightFactor;
+  currentOffsetY = isFirstBlock ? EFFECT_START_Y : currentOffsetY - lineHeight + lineHeight * prePhaseLineHeightFactor;
 
   // Get the phase icon to use
   const phaseIconKey = PHASE_ICON_MAP.get(phase) + (useHighContrastPhaseLabels ? " High Contrast" : "");
@@ -832,7 +832,7 @@ function drawSimpleBlock(simpleContent, isFirstBlock) {
       // Check to see if the line should wrap
       let wrapped = false;
       // Looks forward to see if adding this word to the current line would make the line exceed the maximum x position
-      if (currentOffsetX + spaceWidth + wordWidth > effectEndX) {
+      if (currentOffsetX + spaceWidth + wordWidth > EFFECT_END_X) {
         // If it would, then start the next line
         currentOffsetY += lineHeight;
         currentOffsetX = currentIndentX;
@@ -879,7 +879,7 @@ function drawSimpleBlock(simpleContent, isFirstBlock) {
   });
 
   // After drawing all the words, prepare for the next block
-  currentOffsetX = effectStartX;
+  currentOffsetX = EFFECT_START_X;
   currentOffsetY += lineHeight * blockSpacingFactor;
 }
 

--- a/common-before.js
+++ b/common-before.js
@@ -231,11 +231,11 @@ const EFFECT_START_X = _effectStartXMap.get(CARD_FORM)?.get(ORIENTATION);
 // The X position to stop drawing effect text
 const _effectEndXMap = new Map([
     [DECK, new Map([
-        [VERTICAL, pw(101 - 12.5)],
-        [HORIZONTAL, pw(101 - 7)],
+        [VERTICAL, pw(88.5)],
+        [HORIZONTAL, pw(94)],
     ])],
     [CHARACTER, new Map([
-        [VERTICAL, pw(101 - 14.5)],
+        [VERTICAL, pw(86.5)],
         // Intentionally null. See TODO: HORIZONTAL CHARACTERS above
         [HORIZONTAL, null],
     ])],

--- a/environment-deck-back/index.html
+++ b/environment-deck-back/index.html
@@ -174,6 +174,7 @@
   <script>
     const CARD_FORM = "back";
     const ORIENTATION = "horizontal";
+    const FACE = "back";
     const DEFAULT_DOWNLOAD_NAME = "environment-deck-back";
   </script>
   <!-- Common script -->

--- a/environment-deck-front/index.html
+++ b/environment-deck-front/index.html
@@ -210,6 +210,7 @@
   <script>
     const CARD_FORM = "deck";
     const ORIENTATION = "horizontal";
+    const FACE = "front";
     const DEFAULT_DOWNLOAD_NAME = "environment-deck-front";
   </script>
   <!-- Common script -->

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -105,8 +105,6 @@ function parseJSONData(data) {
 Effect text values
 ============================================================================
 */
-const effectPhaseStartX = pw(61.5); // Left boundary of phase label images
-
 const effectBaseLineHeight = ph(5);
 let lineHeight = effectBaseLineHeight * effectFontScale; // Distance between two lines in the same paragraph
 const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distance between two blocks

--- a/environment-deck-front/script.js
+++ b/environment-deck-front/script.js
@@ -105,14 +105,6 @@ function parseJSONData(data) {
 Effect text values
 ============================================================================
 */
-// Space between words
-const spaceWidthFactor = 0.26;
-let spaceWidth = effectFontSize * spaceWidthFactor;
-
-const effectMarginXPercent = 7; // Percent of width on each side of text
-const effectStartX = pw(50 + effectMarginXPercent); // Left boundary of effect text
-const effectEndX = pw(100 - effectMarginXPercent + 1); // Right boundary of effect text
-const effectStartY = ph(28); // Top boundary of effect text
 const effectPhaseStartX = pw(61.5); // Left boundary of phase label images
 
 const effectBaseLineHeight = ph(5);
@@ -121,7 +113,7 @@ const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distan
 const prePhaseLineHeightFactor = 1.2; // Spacing above phase block
 const postPhaseLineHeightFactor = 1.05; // Spacing below phase block
 
-let currentIndentX = effectStartX; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
+let currentIndentX = EFFECT_START_X; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
 let currentOffsetX = 0; // Current x position for draw commands
 let currentOffsetY = 0; // Current y position for draw commands
 

--- a/hero-character-card-back/index.html
+++ b/hero-character-card-back/index.html
@@ -200,6 +200,7 @@
   <script>
     const CARD_FORM = "character";
     const ORIENTATION = "vertical";
+    const FACE = "back";
     const DEFAULT_DOWNLOAD_NAME = "hero-character-back";
   </script>
   <!-- Common script -->

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -184,23 +184,13 @@ function drawCardCanvas() {
 Effect text values
 ============================================================================
 */
-// Space between words
-const spaceWidthFactor = 0.26;
-let spaceWidth = effectFontSize * spaceWidthFactor;
-
-const effectMarginXPercent = 14.5; // Percent of width on each side of text
-const effectStartX = pw(effectMarginXPercent); // Left boundary of effect text
-const effectEndX = pw(100 - effectMarginXPercent + 1); // Right boundary of effect text
-const effectStartY = ph(86); // Top boundary of effect text
-const effectPhaseStartX = pw(6.5); // Left boundary of phase label images
-
 const effectBaseLineHeight = pw(5);
 let lineHeight = effectBaseLineHeight * effectFontScale; // Distance between two lines in the same paragraph
 const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distance between two blocks
 const prePhaseLineHeightFactor = 1.2; // Spacing above phase block
 const postPhaseLineHeightFactor = 1.05; // Spacing below phase block
 
-let currentIndentX = effectStartX; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
+let currentIndentX = EFFECT_START_X; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
 let currentOffsetX = 0; // Current x position for draw commands
 let currentOffsetY = 0; // Current y position for draw commands
 

--- a/hero-character-card-front/index.html
+++ b/hero-character-card-front/index.html
@@ -279,6 +279,7 @@
   <script>
     const CARD_FORM = "character";
     const ORIENTATION = "vertical";
+    const FACE = "front";
     const DEFAULT_DOWNLOAD_NAME = "hero-character-front";
   </script>
   <!-- Common script -->

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -244,23 +244,13 @@ function drawHP() {
 Effect text values
 ============================================================================
 */
-// Space between words
-const spaceWidthFactor = 0.26;
-let spaceWidth = effectFontSize * spaceWidthFactor;
-
-const effectMarginXPercent = 12.5; // Percent of width on each side of text
-const effectStartX = pw(effectMarginXPercent); // Left boundary of effect text
-const effectEndX = pw(100 - effectMarginXPercent + 1); // Right boundary of effect text
-const effectStartY = ph(85.5); // Top boundary of effect text
-const effectPhaseStartX = pw(6.5); // Left boundary of phase label images
-
 const effectBaseLineHeight = pw(5);
 let lineHeight = effectBaseLineHeight * effectFontScale; // Distance between two lines in the same paragraph
 const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distance between two blocks
 const prePhaseLineHeightFactor = 1.2; // Spacing above phase block
 const postPhaseLineHeightFactor = 1.05; // Spacing below phase block
 
-let currentIndentX = effectStartX; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
+let currentIndentX = EFFECT_START_X; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
 let currentOffsetX = 0; // Current x position for draw commands
 let currentOffsetY = 0; // Current y position for draw commands
 

--- a/hero-deck-back/index.html
+++ b/hero-deck-back/index.html
@@ -257,6 +257,7 @@
   <script>
     const CARD_FORM = "back";
     const ORIENTATION = "vertical";
+    const FACE = "back";
     const DEFAULT_DOWNLOAD_NAME = "hero-deck-back";
   </script>
   <!-- Common script -->

--- a/hero-deck-front/index.html
+++ b/hero-deck-front/index.html
@@ -217,6 +217,7 @@
   <script>
     const CARD_FORM = "deck";
     const ORIENTATION = "vertical";
+    const FACE = "front";
     const DEFAULT_DOWNLOAD_NAME = "hero-deck-front";
   </script>
   <!-- Common script -->

--- a/hero-deck-front/script.js
+++ b/hero-deck-front/script.js
@@ -138,23 +138,13 @@ function outputJSONData() {
 Effect text values
 ============================================================================
 */
-// Space between words
-const spaceWidthFactor = 0.26;
-let spaceWidth = effectFontSize * spaceWidthFactor;
-
-const effectMarginXPercent = 12.5; // Percent of width on each side of text
-const effectStartX = pw(effectMarginXPercent); // Left boundary of effect text
-const effectEndX = pw(100 - effectMarginXPercent + 1); // Right boundary of effect text
-const effectStartY = ph(61.5); // Top boundary of effect text
-const effectPhaseStartX = pw(6.5); // Left boundary of phase label images
-
 const effectBaseLineHeight = pw(5);
 let lineHeight = effectBaseLineHeight * effectFontScale; // Distance between two lines in the same paragraph
 const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distance between two blocks
 const prePhaseLineHeightFactor = 1.2; // Spacing above phase block
 const postPhaseLineHeightFactor = 1.05; // Spacing below phase block
 
-let currentIndentX = effectStartX; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
+let currentIndentX = EFFECT_START_X; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
 let currentOffsetX = 0; // Current x position for draw commands
 let currentOffsetY = 0; // Current y position for draw commands
 

--- a/villain-deck-back/index.html
+++ b/villain-deck-back/index.html
@@ -247,6 +247,7 @@
   <script>
     const CARD_FORM = "back";
     const ORIENTATION = "vertical";
+    const FACE = "back";
     const DEFAULT_DOWNLOAD_NAME = "villain-deck-back";
   </script>
   <!-- Common script -->

--- a/villain-deck-front/index.html
+++ b/villain-deck-front/index.html
@@ -205,6 +205,7 @@
   <script>
     const CARD_FORM = "deck";
     const ORIENTATION = "vertical";
+    const FACE = "front";
     const DEFAULT_DOWNLOAD_NAME = "villain-deck-front";
   </script>
   <!-- Common script -->

--- a/villain-deck-front/script.js
+++ b/villain-deck-front/script.js
@@ -3,23 +3,13 @@
 Effect text values
 ============================================================================
 */
-// Space between words
-const spaceWidthFactor = 0.26;
-let spaceWidth = effectFontSize * spaceWidthFactor;
-
-const effectMarginXPercent = 12.5; // Percent of width on each side of text
-const effectStartX = pw(effectMarginXPercent); // Left boundary of effect text
-const effectEndX = pw(100 - effectMarginXPercent + 1); // Right boundary of effect text
-const effectStartY = ph(61.5); // Top boundary of effect text
-const effectPhaseStartX = pw(6.5); // Left boundary of phase label images
-
 const effectBaseLineHeight = pw(5);
 let lineHeight = effectBaseLineHeight * effectFontScale; // Distance between two lines in the same paragraph
 const blockSpacingFactor = 1.3; // Multiply lineHeight by this to get the distance between two blocks
 const prePhaseLineHeightFactor = 1.2; // Spacing above phase block
 const postPhaseLineHeightFactor = 1.05; // Spacing below phase block
 
-let currentIndentX = effectStartX; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
+let currentIndentX = EFFECT_START_X; // Different x position to reset to when drawing a block with an indent (such as a POWER:)
 let currentOffsetX = 0; // Current x position for draw commands
 let currentOffsetY = 0; // Current y position for draw commands
 


### PR DESCRIPTION
## Summary
- Added a new configuration, `FACE`, with values `FRONT = "front"` and `BACK = "back"`.
- Moved the `TODO` for horizontal character cards to the top of the page so I don't copy/paste those same lines a bunch of times. Added a comment pointing to it in each map.
- Removed `effectPhaseStartX` which doesn't seem to be used for anything.
- Removed `effectMarginXPercent` since it required special arithmetic for `effectStartX` with environment decks anyways.
- Refactored `effectStartX` to `EFFECT_START_X` and moved it into `common-before.js`.
- Refactored `effectEndX` to `EFFECT_END_X` and moved it into `common-before.js`.
- Refactored `effectStartY` to `EFFECT_START_Y` and moved it into `common-before.js` -- this value depends on the new `FACE` configuration.
- Refactored `spaceWidthFactor` to `SPACE_WIDTH_FACTOR` and moved it into `common-before.js`.
- Moved `spaceWidth` into `common-before.js`.
- Initialized `suddenly` and `useHighContrastPhaseLabels` based on the state of their relevant checkboxes so that the checkboxes work nicely when hot reloading.

## Test Plan
Render 'em all. Make sure they work.

## Screenshots
Second verse, same as the first

![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/83243f90-81eb-4a07-81f9-72b444a377cf)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/817463cc-ad92-48da-ad3b-4b9e5a1ff6e6)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/e55a92ac-f246-474a-9e70-5dba1b53d484)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/ce702fcc-4acf-4449-b17f-8062251f4e59)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/97f89105-eac7-4a25-96c8-6e0e6bd3a413)

## Reviewers
@Colcoction 
@sjzhu 