### PR TITLE
Add front/back to _effectStartXMap

### DIFF
--- a/common-before.js
+++ b/common-before.js
@@ -243,16 +243,27 @@ const EFFECT_BASE_FONT_SIZE = _baseFontSizeMap.get(CARD_FORM)?.get(ORIENTATION);
 // The X position to begin drawing effect text
 const _effectStartXMap = new Map([
     [DECK, new Map([
-        [VERTICAL, pw(12.5)],
-        [HORIZONTAL, pw(57)],
+        [VERTICAL, new Map([
+            [FRONT, pw(12.5)],
+            // Deck backs don't have effect text
+            [BACK, null],
+        ])],
+        [HORIZONTAL, new Map([
+            [FRONT, pw(57)],
+            // Deck backs don't have effect text
+            [BACK, null],
+        ])],
     ])],
     [CHARACTER, new Map([
-        [VERTICAL, pw(14.5)],
+        [VERTICAL, new Map([
+            [FRONT, pw(12.5)],
+            [BACK, pw(14.5)]
+        ])],
         // Intentionally null. See TODO: HORIZONTAL CHARACTERS above
         [HORIZONTAL, null],
     ])],
 ]);
-const EFFECT_START_X = _effectStartXMap.get(CARD_FORM)?.get(ORIENTATION);
+const EFFECT_START_X = _effectStartXMap.get(CARD_FORM)?.get(ORIENTATION)?.get(FACE);
 
 // The X position to stop drawing effect text
 const _effectEndXMap = new Map([


### PR DESCRIPTION
## Summary

This adds `FACE`-based configs to the `_effectStartXMap` (and uses `FACE` when setting `EFFECT_START_X` so that body text for a character card front is properly positioned. This matches the behavior of `_effectStartYMap` now... which should have been a sign to me that I was doing something wrong.

## Test Plan
1. Create character card fronts & backs. Verify that the content lines up with headers for the cards.
2. Open up the other card fronts and type some stuff in. Just verify that nothing is broken, and that text renders without error.

## Screenshotss
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/bee0af57-111f-4a30-b742-241d1d88b984)
![image](https://github.com/Colcoction/unitys-workshop/assets/8094985/1d13595d-7072-4f03-a85a-7ca1806fcc3b)

## Reviewers
@sjzhu @Colcoction 