### PR TITLE
Fix variant tag being behind foreground art

### DIFF
--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -115,11 +115,6 @@ function drawCardCanvas() {
   // === Draw the background art
   drawArtInCroppedArea('hccf_backgroundArt');
 
-  // Draw the variant tag if it's enabled
-  if (isVariant) {
-    drawVariantTag();
-  }
-
   if (showBorder) {
     // === Draw the card border
     ctx.drawImage(loadedGraphics['Border'], 0, 0, canvas.width, canvas.height);
@@ -132,7 +127,11 @@ function drawCardCanvas() {
   // Draw the character body box, and the text in the card body.
   drawCharacterBodyBox();
   drawBodyText(parsedBlocks);
-
+  
+  // Draw the variant tag if it's enabled
+  if (isVariant) {
+    drawVariantTag();
+  }
 
   // == Draw the power name
   const powerNameX = pw(12.5);


### PR DESCRIPTION
## What?

Fixing a small bug with Hero CCs where the VARIANT tag is layered behind foreground art. Moved it to in front of the effect box  (willing to be overruled on this). 

## How was it tested?

Screenshot: 
![image](https://github.com/Colcoction/unitys-workshop/assets/1555041/0608cdc1-80da-444e-8233-7592c74e8527)

## Reviewers
@Colcoction @alexdarling @Fosuke 