### PR TITLE
[refactor] Refactor logo names to be identical across card types

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -172,10 +172,10 @@ imageAreas = {
     scaleStyle: 'fit',
     vAlign: 'top',
     getImage: function () {
-      return getUserImage('heroNameArt');
+      return getUserImage('nameLogo');
     },
     getAdjustments: function () {
-      return getUserImageAdjustments('heroNameArt');
+      return getUserImageAdjustments('nameLogo');
     }
   },
   // Art in Foreground
@@ -320,10 +320,10 @@ imageAreas = {
     scaleStyle: 'fit',
     vAlign: 'top',
     getImage: function () {
-      return getUserImage('heroNameArt');
+      return getUserImage('nameLogo');
     },
     getAdjustments: function () {
-      return getUserImageAdjustments('heroNameArt');
+      return getUserImageAdjustments('nameLogo');
     }
   },
   // Left Art
@@ -391,10 +391,10 @@ imageAreas = {
     scaleStyle: 'fit',
     vAlign: 'top',
     getImage: function () {
-      return getUserImage('villainNameArt');
+      return getUserImage('nameLogo');
     },
     getAdjustments: function () {
-      return getUserImageAdjustments('villainNameArt');
+      return getUserImageAdjustments('nameLogo');
     }
   },
   // Top Art

--- a/hero-character-card-front/index.html
+++ b/hero-character-card-front/index.html
@@ -257,22 +257,22 @@
 
       <div class="inputGroup">
         <label for="inputImageFile">Name Logo</label>
-        <input type="file" accept="image/*" data-image-purpose="heroNameArt" class="contentInput inputImageFile">
+        <input type="file" accept="image/*" data-image-purpose="nameLogo" class="contentInput inputImageFile">
         <details>
           <summary>Adjustment Controls</summary>
           <label for="inputImageOffsetX" style="margin-top: 10px;">X Position</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageOffsetY">Y Position</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageOffsetY rangeSlider" min="-50" max="50" data-default="0">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetY rangeSlider" min="-50" max="50" data-default="0">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageScale">Zoom</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageScale rangeSlider" min="50" max="500" data-default="100">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="100">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageScale rangeSlider" min="50" max="500" data-default="100">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="100">
 
-          <button style="margin-top: 10px;" data-image-purpose="heroNameArt" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
+          <button style="margin-top: 10px;" data-image-purpose="nameLogo" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
         </details>
       </div>
 

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -67,7 +67,8 @@ $('#inputImageFile').on('input', function (e) {
 let loadedUserImages = {
   backgroundArt: null,
   foregroundArt: null,
-  nemesisIcon: null
+  nemesisIcon: null,
+  nameLogo: null
 };
 
 

--- a/hero-deck-back/index.html
+++ b/hero-deck-back/index.html
@@ -150,23 +150,23 @@
 
       <div class="inputGroup">
         <label for="inputImageFile">Name Logo</label>
-        <input type="file" accept="image/*" data-image-purpose="heroNameArt" class="contentInput inputImageFile" id="">
+        <input type="file" accept="image/*" data-image-purpose="nameLogo" class="contentInput inputImageFile" id="">
         <details>
           <summary>Adjustment Controls</summary>
           <!-- These ranges all represent percents, ex: 50 = 50% or times 0.5 -->
           <label for="inputImageOffsetX" style="margin-top: 10px;">X Position</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageOffsetY">Y Position</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="10">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="10">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="10">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="10">
 
           <label for="inputImageScale">Zoom</label>
-          <input type="range" data-image-purpose="heroNameArt" class="contentInput inputImageScale rangeSlider" min="50" max="200" data-default="90">
-          <input type="text" data-image-purpose="heroNameArt" class="contentInput rangeText" data-default="90">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageScale rangeSlider" min="50" max="200" data-default="90">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="90">
 
-          <button style="margin-top: 10px;" data-image-purpose="heroNameArt" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
+          <button style="margin-top: 10px;" data-image-purpose="nameLogo" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
         </details>
       </div>
     </div>

--- a/hero-deck-back/script.js
+++ b/hero-deck-back/script.js
@@ -39,7 +39,7 @@ let loadedUserImages = {
   leftArt: null,
   rightArt: null,
   bottomArt: null,
-  heroNameArt: null
+  nameLogo: null
 };
 
 

--- a/villain-deck-back/index.html
+++ b/villain-deck-back/index.html
@@ -140,23 +140,23 @@
 
       <div class="inputGroup">
         <label for="inputImageFile">Name Logo</label>
-        <input type="file" accept="image/*" data-image-purpose="villainNameArt" class="contentInput inputImageFile" id="">
+        <input type="file" accept="image/*" data-image-purpose="nameLogo" class="contentInput inputImageFile" id="">
         <details>
           <summary>Adjustment Controls</summary>
           <!-- These ranges all represent percents, ex: 50 = 50% or times 0.5 -->
           <label for="inputImageOffsetX" style="margin-top: 10px;">X Position</label>
-          <input type="range" data-image-purpose="villainNameArt" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
-          <input type="text" data-image-purpose="villainNameArt" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetX rangeSlider" min="-50" max="50" data-default="0">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageOffsetY">Y Position</label>
-          <input type="range" data-image-purpose="villainNameArt" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="0">
-          <input type="text" data-image-purpose="villainNameArt" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="100" data-default="0">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
 
           <label for="inputImageScale">Zoom</label>
-          <input type="range" data-image-purpose="villainNameArt" class="contentInput inputImageScale rangeSlider" min="50" max="200" data-default="90">
-          <input type="text" data-image-purpose="villainNameArt" class="contentInput rangeText" data-default="90">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageScale rangeSlider" min="50" max="200" data-default="90">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="90">
 
-          <button style="margin-top: 10px;" data-image-purpose="villainNameArt" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
+          <button style="margin-top: 10px;" data-image-purpose="nameLogo" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
         </details>
       </div>
     </div>

--- a/villain-deck-back/script.js
+++ b/villain-deck-back/script.js
@@ -39,7 +39,7 @@ let loadedUserImages = {
   leftArt: null,
   rightArt: null,
   topArt: null,
-  villainNameArt: null
+  nameLogo: null
 };
 
 


### PR DESCRIPTION
## What?
Refactor the various names for logo art to be `nameLogo` to be consistent. This will also help a future JSON import/export PR.

## How was this tested?
Tested with existing card logos and the like on all the pages.
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/a6b8a7d5-71ab-46af-afe1-caa10b09d2e8">
<img width="935" alt="image" src="https://github.com/user-attachments/assets/25730b2b-9d32-4051-ac99-e0e246bc7cb8">
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/a1316efb-89bb-4f53-aea3-e11af2b32567">
<img width="931" alt="image" src="https://github.com/user-attachments/assets/af818ca3-eaf4-4fc4-b7bd-785f54e89993">

## Reviewers
@Colcoction 