### PR TITLE
Increase draw area for vcc name logo

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -238,10 +238,10 @@ imageAreas = {
   // Villain Name
   vcc_nameLogo: {
     pathShape: coordinatesToPathShape([
-      [50, 2],
-      [98.5, 2],
-      [98.5, 40],
-      [50, 40]
+      [0.5, 2],
+      [99.5, 2],
+      [99.5, 40],
+      [0.5, 40]
     ]),
     scaleStyle: 'fit',
     vAlign: 'top',

--- a/villain-character-card/index.html
+++ b/villain-character-card/index.html
@@ -221,16 +221,16 @@
         <details>
           <summary>Adjustment Controls</summary>
           <label for="inputImageOffsetX" style="margin-top: 10px;">X Position</label>
-          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetX rangeSlider" min="-70" max="70" data-default="0">
-          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetX rangeSlider" min="-80" max="80" data-default="50">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="50">
 
           <label for="inputImageOffsetY">Y Position</label>
-          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="50" data-default="0">
-          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="0">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageOffsetY rangeSlider" min="-100" max="50" data-default="-20">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="-20">
 
           <label for="inputImageScale">Zoom</label>
-          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageScale rangeSlider" min="50" max="200" data-default="100">
-          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="100">
+          <input type="range" data-image-purpose="nameLogo" class="contentInput inputImageScale rangeSlider" min="10" max="200" data-default="50">
+          <input type="text" data-image-purpose="nameLogo" class="contentInput rangeText" data-default="50">
 
           <button style="margin-top: 10px;" data-image-purpose="nameLogo" class="adjustmentResetButton clearImageButton">Clear Image and Adjustments</button>
         </details>


### PR DESCRIPTION
## What?
Increase the draw area for the Villain CC name logo so it can go to the left side of the card as well to support cards that have large amounts of text. Also so we can support _beeg_ logos.

## How was this tested?
Locally:
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/24d296d8-5027-4a8c-9eec-6e974ecbeaed">
<img width="882" alt="image" src="https://github.com/user-attachments/assets/b2edf6a9-6ca5-4749-ba0a-0a5d6f384b55">

## Reviewers
@Colcoction 