### PR TITLE
JSON Parse Fixes

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -692,13 +692,14 @@ function parseJSONData(data) {
   if('ImageZoom' in data) {
     // special parsing for the zoom value, as if it's fed a non-number, it will
     // default to the middle of the bar, which is not the default
+    // ImageZoom is used for card fronts, so it defaults to 100
     let zoomVal = parseInt(data.ImageZoom);
     if (zoomVal == NaN) {
-      zoomVal = 0;
+      zoomVal = 100;
     }
     $('.inputImageScale').val(zoomVal);
   } else {
-    $('.inputImageScale').val(0);
+    $('.inputImageScale').val(100);
   }
   if ($('#suddenly').length > 0) {
     if('Suddenly' in data && data.Suddenly.toUpperCase() == "TRUE") {

--- a/common-before.js
+++ b/common-before.js
@@ -523,3 +523,8 @@ let inputBelowNameLogoAlignment = 1;
 
 // How much the border in a Villain character card should adjust to fit the setup text
 let setupBorderOffset = 0;
+
+// This object is where user input images (specifically Image objects) are stored
+// currently unused for deck fronts, but needs to exist for JSON parsing to function correctly
+let loadedUserImages = {
+};

--- a/common-before.js
+++ b/common-before.js
@@ -137,6 +137,13 @@ const BACK_RIGHT_ART = "rightArt";
 const BACK_BOTTOM_ART = "bottomArt";
 const NAME_LOGO = "nameLogo";
 
+// Common Image Sets
+const CC_FRONT_IMAGES = new Set([BACKGROUND_ART, FOREGROUND_ART, NEMESIS_ICON, NAME_LOGO]);
+const CC_BACK_IMAGES = new Set([BACKGROUND_ART]);
+const VCC_IMAGES = new Set([BACKGROUND_ART, FOREGROUND_ART, NEMESIS_ICON, NAME_LOGO]);
+const HERO_DECK_BACK_IMAGES = new Set([BACK_LEFT_ART, BACK_RIGHT_ART, BACK_BOTTOM_ART, NAME_LOGO]);
+const VILLAIN_DECK_BACK_IMAGES = new Set([BACK_TOP_ART, BACK_LEFT_ART, BACK_RIGHT_ART, NAME_LOGO]);
+
 // Common image style classes
 const IMAGE_X = "inputImageOffsetX"
 const IMAGE_Y = "inputImageOffsetY"
@@ -460,6 +467,11 @@ const _quoteWidthMap = new Map([
 ]);
 const QUOTE_WIDTH = _quoteWidthMap.get(CARD_FORM)?.get(ORIENTATION)?.get(FACE);
 
+// This object is where user input images (specifically Image objects) are stored
+// currently unused for deck fronts, but needs to exist for JSON parsing to function correctly
+const loadedUserImages = {
+};
+
 
 /*
 ============================================================================
@@ -523,8 +535,3 @@ let inputBelowNameLogoAlignment = 1;
 
 // How much the border in a Villain character card should adjust to fit the setup text
 let setupBorderOffset = 0;
-
-// This object is where user input images (specifically Image objects) are stored
-// currently unused for deck fronts, but needs to exist for JSON parsing to function correctly
-let loadedUserImages = {
-};

--- a/hero-character-card-back/script.js
+++ b/hero-character-card-back/script.js
@@ -62,10 +62,7 @@ $('#inputImageFile').on('input', function (e) {
 })
 
 // This object is where user input images (specifically Image objects) are stored
-let loadedUserImages = {
-  backgroundArt: null
-};
-
+CC_BACK_IMAGES.forEach(key => loadedUserImages[key] = null);
 
 // Handle user image uploading
 $('.inputImageFile').on('input', function () {

--- a/hero-character-card-front/script.js
+++ b/hero-character-card-front/script.js
@@ -64,13 +64,7 @@ $('#inputImageFile').on('input', function (e) {
 })
 
 // This object is where user input images (specifically Image objects) are stored
-let loadedUserImages = {
-  backgroundArt: null,
-  foregroundArt: null,
-  nemesisIcon: null,
-  nameLogo: null
-};
-
+CC_FRONT_IMAGES.forEach(key => loadedUserImages[key] = null);
 
 // Handle user image uploading
 $('.inputImageFile').on('input', function () {

--- a/hero-deck-back/script.js
+++ b/hero-deck-back/script.js
@@ -33,15 +33,8 @@ for (let i = 0; i < imagesToPreload.length; i++) {
   }
 }
 
-
 // This object is where user input images (specifically Image objects) are stored
-let loadedUserImages = {
-  leftArt: null,
-  rightArt: null,
-  bottomArt: null,
-  nameLogo: null
-};
-
+HERO_DECK_BACK_IMAGES.forEach(key => loadedUserImages[key] = null);
 
 // Handle user image uploading
 $('.inputImageFile').on('input', function () {

--- a/villain-character-card/script.js
+++ b/villain-character-card/script.js
@@ -67,12 +67,7 @@ $('#inputImageFile').on('input', function (e) {
 })
 
 // This object is where user input images (specifically Image objects) are stored
-let loadedUserImages = {
-  backgroundArt: null,
-  foregroundArt: null,
-  nemesisIcon: null
-};
-
+VCC_IMAGES.forEach(key => loadedUserImages[key] = null);
 
 // Handle user image uploading
 $('.inputImageFile').on('input', function () {

--- a/villain-deck-back/script.js
+++ b/villain-deck-back/script.js
@@ -33,15 +33,8 @@ for (let i = 0; i < imagesToPreload.length; i++) {
   }
 }
 
-
 // This object is where user input images (specifically Image objects) are stored
-let loadedUserImages = {
-  leftArt: null,
-  rightArt: null,
-  topArt: null,
-  nameLogo: null
-};
-
+VILLAIN_DECK_BACK_IMAGES.forEach(key => loadedUserImages[key] = null);
 
 // Handle user image uploading
 $('.inputImageFile').on('input', function () {


### PR DESCRIPTION
## What?
Some small fixes for https://github.com/Colcoction/unitys-workshop/pull/30, which apparently has been slightly broken ever since that went out. If you don't fill in a number for ImageZoom, it defaults to 0 (50 with the limits on the zoom bar). In addition, the parse function throws an error that loadedUserImages doesn't exist whenever you JSON import for a deck front. This PR fixes both of those issues.

## How was it tested?
Locally. 
![image](https://github.com/user-attachments/assets/e14a6225-7a23-41ae-986b-1fefa8680b5c)

## Reviewers
@Colcoction 