### PR TITLE
[JSON] Fix suddenly parsing in JSON input to handle both bool and string

### DIFF
--- a/common-after.js
+++ b/common-after.js
@@ -701,15 +701,20 @@ function parseJSONData(data) {
   } else {
     $('.inputImageScale').val(100);
   }
+
+  // this is complicated to allow for the fact that suddenly can be either a string or a boolean, depending on how people input it
   if ($('#suddenly').length > 0) {
-    if('Suddenly' in data && data.Suddenly.toUpperCase() == "TRUE") {
-      $('#suddenly')[0].checked = true;
-      suddenly = true;
+    if ('Suddenly' in data) {
+      const isSuddenlyTrue = (typeof data.Suddenly === 'boolean' && data.Suddenly) ||
+                             (typeof data.Suddenly === 'string' && data.Suddenly.toUpperCase() === 'TRUE');
+      $('#suddenly')[0].checked = isSuddenlyTrue;
+      suddenly = isSuddenlyTrue;
     } else {
       $('#suddenly')[0].checked = false;
       suddenly = false;
     }
   }
+
   // Hero Character card fields
   if('PowerName' in data) {
     $('#inputPowerName').val(data.PowerName);


### PR DESCRIPTION
## What?
Fixing the parsing in the JSON method to handle both bool and string cases. Before, the JSON input assumed the input was a string, while the JSON output created a boolean. Oops.

## How was this tested?
Locally. 
![image](https://github.com/user-attachments/assets/73b898c0-db3b-4962-8009-5727dde1d992)

## Reviewers
@Colcoction 